### PR TITLE
Set pointer Events to none for cat sprite.

### DIFF
--- a/oneko.js
+++ b/oneko.js
@@ -60,6 +60,7 @@
         nekoEl.style.width = "32px";
         nekoEl.style.height = "32px";
         nekoEl.style.position = "fixed";
+        nekoEl.style.pointerEvents = "none";
         nekoEl.style.backgroundImage = "url('./oneko.gif')";
         nekoEl.style.imageRendering = "pixelated";
         nekoEl.style.left = "16px";


### PR DESCRIPTION
Set pointer Events to none, so it does not interfere with elements/buttons behind the cat.