### PR TITLE
Function name typo

### DIFF
--- a/oneko-webring.js
+++ b/oneko-webring.js
@@ -12,7 +12,7 @@
   const isReducedMotion =
     window.matchMedia(`(prefers-reduced-motion: reduce)`) === true ||
     window.matchMedia(`(prefers-reduced-motion: reduce)`).matches === true;
-  
+
   if (isReducedMotion) {
     return;
   }
@@ -27,7 +27,7 @@
     "spookyghost.zone",
     "noelle.df1.dev"
   ];
-  
+
   try {
     const searchParams = location.search
       .replace("?", "")
@@ -46,7 +46,7 @@
     console.error("oneko.js: failed to parse query params.");
     console.error(e);
   }
-  
+
   function onClick(event) {
     let target;
     if (event.target.tagName === "A" && event.target.getAttribute("href")) {
@@ -165,13 +165,13 @@
       mousePosX = event.clientX;
       mousePosY = event.clientY;
     });
-    
-    window.requestAnimationFrame(onAnimatonFrame);
+
+    window.requestAnimationFrame(onAnimationFrame);
   }
 
   let lastFrameTimestamp;
 
-  function onAnimatonFrame(timestamp) {
+  function onAnimationFrame(timestamp) {
     // Stops execution if the neko element is removed from DOM
     if (!nekoEl.isConnected) {
       return;
@@ -182,9 +182,9 @@
     if (timestamp - lastFrameTimestamp > 100) {
       lastFrameTimestamp = timestamp
       frame()
-    } 
+    }
 
-    window.requestAnimationFrame(onAnimatonFrame);
+    window.requestAnimationFrame(onAnimationFrame);
   }
 
   function setSprite(name, frame) {

--- a/oneko.js
+++ b/oneko.js
@@ -12,7 +12,7 @@
   const isReducedMotion =
     window.matchMedia(`(prefers-reduced-motion: reduce)`) === true ||
     window.matchMedia(`(prefers-reduced-motion: reduce)`).matches === true;
-  
+
   if (isReducedMotion) {
     return;
   }
@@ -105,13 +105,13 @@
       mousePosX = event.clientX;
       mousePosY = event.clientY;
     });
-    
-    window.requestAnimationFrame(onAnimatonFrame);
+
+    window.requestAnimationFrame(onAnimationFrame);
   }
 
   let lastFrameTimestamp;
 
-  function onAnimatonFrame(timestamp) {
+  function onAnimationFrame(timestamp) {
     // Stops execution if the neko element is removed from DOM
     if (!nekoEl.isConnected) {
       return;
@@ -123,7 +123,7 @@
       lastFrameTimestamp = timestamp
       frame()
     }
-    window.requestAnimationFrame(onAnimatonFrame);
+    window.requestAnimationFrame(onAnimationFrame);
   }
 
   function setSprite(name, frame) {


### PR DESCRIPTION
I fixed a typo in a function name. And also my editor picked up a bunch of trailing whitespace automatically so that's gone too.