### PR TITLE
Add custom cat support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 A hacky script I wrote to put a cat on my site.
 
+The default image is `oneko.gif` in the same directory as the script. This can be changed by adding `data-cat="yourimage.png"` to your `<script>` tag.
+
 https://adryd.com
 
 implemented in a few different places
- - Userscript: https://openuserjs.org/scripts/sjehuda/Oneko_WebMate
- - Vencord: https://vencord.dev/plugins/oneko
- - Spicetify: https://github.com/kyrie25/spicetify-oneko
+  - Userscript: https://openuserjs.org/scripts/sjehuda/Oneko_WebMate
+  - Vencord: https://vencord.dev/plugins/oneko
+  - Spicetify: https://github.com/kyrie25/spicetify-oneko

--- a/oneko-webring.js
+++ b/oneko-webring.js
@@ -155,11 +155,17 @@
     nekoEl.style.height = "32px";
     nekoEl.style.position = "fixed";
     nekoEl.style.pointerEvents = "none";
-    nekoEl.style.backgroundImage = "url('./oneko.gif')";
     nekoEl.style.imageRendering = "pixelated";
     nekoEl.style.left = `${nekoPosX - 16}px`;
     nekoEl.style.top = `${nekoPosY - 16}px`;
     nekoEl.style.zIndex = Number.MAX_VALUE;
+
+    let nekoFile = "./oneko.gif"
+    const curScript = document.currentScript
+    if (curScript && curScript.dataset.cat) {
+      nekoFile = curScript.dataset.cat
+    }
+    nekoEl.style.backgroundImage = `url(${nekoFile})`;
 
     document.body.appendChild(nekoEl);
 

--- a/oneko.js
+++ b/oneko.js
@@ -93,11 +93,17 @@
     nekoEl.style.height = "32px";
     nekoEl.style.position = "fixed";
     nekoEl.style.pointerEvents = "none";
-    nekoEl.style.backgroundImage = "url('./oneko.gif')";
     nekoEl.style.imageRendering = "pixelated";
     nekoEl.style.left = `${nekoPosX - 16}px`;
     nekoEl.style.top = `${nekoPosY - 16}px`;
     nekoEl.style.zIndex = Number.MAX_VALUE;
+
+    let nekoFile = "./oneko.gif"
+    const curScript = document.currentScript
+    if (curScript && curScript.dataset.cat) {
+      nekoFile = curScript.dataset.cat
+    }
+    nekoEl.style.backgroundImage = `url(${nekoFile})`;
 
     document.body.appendChild(nekoEl);
 


### PR DESCRIPTION
Closes #6 

Allows specifying a custom image to use by adding the attribute `data-cat="yourimage.png"` to the script tag. [This implementation](https://caniuse.com/document-currentscript) should have the same backwards compatibility as oneko.js currently does, but I tried to ensure it would safely fallback in the very niche case it breaks. If this isn't a concern, I can simplify it to two lines.

Also documents this feature in the README