### PR TITLE
Fix zIndex on webring oneko

### DIFF
--- a/oneko-webring.js
+++ b/oneko-webring.js
@@ -152,7 +152,7 @@
     nekoEl.style.imageRendering = "pixelated";
     nekoEl.style.left = `${nekoPosX - 16}px`;
     nekoEl.style.top = `${nekoPosY - 16}px`;
-    nekoEl.style.zIndex = Number.MAX_VALUE;
+    nekoEl.style.zIndex = Number.MAX_SAFE_INTEGER;
 
     let nekoFile = "./oneko.gif"
     const curScript = document.currentScript


### PR DESCRIPTION
Number.MAX_VALUE does not seem to work on some browsers, using Number.MAX_SAFE_INTEGER seems to have fixed this.