### PR TITLE
Traverse up from the click target to look for A elements

### DIFF
--- a/oneko-webring.js
+++ b/oneko-webring.js
@@ -20,7 +20,7 @@
   const nekoSites = [
     "localhost",
   ];
-  
+
   try {
     const searchParams = location.search
       .replace("?", "")
@@ -41,18 +41,11 @@
   }
 
   function onClick(event) {
-    let target;
-    if (event.target.tagName === "A" && event.target.getAttribute("href")) {
-      target = event.target;
-    } else if (
-      event.target.tagName == "IMG" &&
-      event.target.parentElement.tagName === "A" &&
-      event.target.parentElement.getAttribute("href")
-    ) {
-      target = event.target.parentElement;
-    } else {
+    const target = event.target.closest("A");
+    if (target === null || !target.getAttribute("href")) {
       return;
     }
+
     let newLocation;
     try {
       newLocation = new URL(target.href);


### PR DESCRIPTION
Previously, when an element was clicked, this script would check two hardcoded cases:
- If the target element of the click is an `<a>` element, and the target element has an `href` attribute
- If the target element of the click is an `<img>` element, the target element's parent is an `<a>` element, and the target element's parent has an `href` attribute

This fails to match in situations where the markup inside the `<a>` element is more complex. For instance, on [breq.dev](https://breq.dev/), to represent the "placeholder" 88x31
badges for friends who have not created them, I use a `<span>` element centered inside a flexbox `<div>`. Since this doesn't satisfy either of the criteria above, it was not 
recognized as a site and the URL query parameters were not appended properly.

This change traverses the DOM upwards using the `closest` method to check if any parent of the target node is an `<a>` element (with a `href` attribute).

