### PR TITLE
Clean up code syntax, make Oneko unselectable

### DIFF
--- a/oneko-webring.js
+++ b/oneko-webring.js
@@ -101,6 +101,7 @@
     nekoEl.style.left = `${nekoPosX - 16}px`;
     nekoEl.style.top = `${nekoPosY - 16}px`;
     nekoEl.style.zIndex = Number.MAX_VALUE;
+	nekoEl.style.userselect = "none";
 
     let nekoFile = "./oneko.gif";
     const curScript = document.currentScript;

--- a/oneko.js
+++ b/oneko.js
@@ -49,6 +49,7 @@
     nekoEl.style.left = `${nekoPosX - 16}px`;
     nekoEl.style.top = `${nekoPosY - 16}px`;
     nekoEl.style.zIndex = 2147483647;
+    nekoEl.style.userselect = "none";
 
     let nekoFile = "./oneko.gif";
     const curScript = document.currentScript;


### PR DESCRIPTION
I cleaned up the syntax a bit so it's more readable. I also noticed an oddity of Oneko "selecting" a blank text box whenever it is double clicked while I was testing a petting function. so, I simply changed it's user-select property so it can no longer be selected like text.

I, however have not made any changes to the IE6 file because I've never worked with pre-IE8 JS before so I won't bother to avoid creating any issues in the future.

(this is my first pull request yay!!!)